### PR TITLE
clickable character sprites, opens unit info

### DIFF
--- a/Resources/Stats/basicCharacter.tres
+++ b/Resources/Stats/basicCharacter.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="Stats" load_steps=2 format=3 uid="uid://cjd6sgx3cubdy"]
 
-[ext_resource type="Script" uid="uid://nrrksgjdl3ta" path="res://Scripts/Stats/stat_sheet.gd" id="1_15778"]
+[ext_resource type="Script" uid="uid://bm1xu5u0p62r0" path="res://Scripts/Stats/stat_sheet.gd" id="1_15778"]
 
 [resource]
 resource_local_to_scene = true

--- a/Resources/Stats/basicEnemy.tres
+++ b/Resources/Stats/basicEnemy.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="Stats" load_steps=2 format=3 uid="uid://dyi7audcba6gf"]
 
-[ext_resource type="Script" uid="uid://nrrksgjdl3ta" path="res://Scripts/Stats/stat_sheet.gd" id="1_ykkkl"]
+[ext_resource type="Script" uid="uid://bm1xu5u0p62r0" path="res://Scripts/Stats/stat_sheet.gd" id="1_ykkkl"]
 
 [resource]
 resource_local_to_scene = true

--- a/Scenes/Camera/OverviewCamera.gd
+++ b/Scenes/Camera/OverviewCamera.gd
@@ -7,7 +7,7 @@ var inputY : int
 var tween : Tween
 
 func track_char_cam(character: Character):
-	if (character.get_child(3).is_on_screen()):
+	if (character.find_child("VisibilityNotifier").is_on_screen()):
 		transition_camera(self, character.find_child("CharacterCamera"), 0.5)
 	else:
 		transition_camera(self, character.find_child("CharacterCamera"), 1.0)

--- a/Scenes/Character/Character.gd
+++ b/Scenes/Character/Character.gd
@@ -1,9 +1,13 @@
 extends Unit
 class_name Character
 
-var in_ui_element: bool
 var mode : String = "idle"
 @onready var path = $Path
+@onready var clickable_area = $ClickableArea
+
+var in_ui_element: bool
+
+signal unit_clicked(unit)
 
 func _ui_element_mouse_entered():
 	in_ui_element = true
@@ -63,13 +67,21 @@ func _input(event):
 func _physics_process(_delta):
 	if self == turn_queue.active_char:
 		if !in_ui_element:
-			var tile_position = tile_layer_zero.local_to_map(get_global_mouse_position())
+			var mouse_pos = get_global_mouse_position()
+			var tile_position = tile_layer_zero.local_to_map(mouse_pos)
+			var grid_size = Vector2i(16, 16)
 			
-			if !is_moving:
-				hover_id_path = astar_grid.get_id_path(
-					tile_layer_zero.local_to_map(global_position),
-					tile_position
-				)
-				hover_id_path = hover_id_path.slice(1, hover_id_path.size() - 1)
+			if tile_position.x >= 0 and tile_position.y >= 0 and tile_position.x < grid_size.x and tile_position.y < grid_size.y:
+				var char_tile_pos = tile_layer_zero.local_to_map(global_position)
+				if tile_position != char_tile_pos:
+					if !is_moving:
+						hover_id_path = astar_grid.get_id_path(
+							tile_layer_zero.local_to_map(global_position),
+							tile_position
+						)
+						hover_id_path = hover_id_path.slice(1, hover_id_path.size() - 1)
 			
 		move_towards_target(_delta)
+
+func _on_area_clicked(parent: Variant) -> void:
+	emit_signal("unit_clicked", self)

--- a/Scenes/Character/Character.tscn
+++ b/Scenes/Character/Character.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://brhl8kkmkf8im"]
+[gd_scene load_steps=7 format=3 uid="uid://brhl8kkmkf8im"]
 
 [ext_resource type="Script" uid="uid://b7rye3k8armrb" path="res://Scenes/Character/Character.gd" id="1_vxr42"]
 [ext_resource type="Script" uid="uid://eyy4qva83pwu" path="res://Scenes/Character/Path.gd" id="2_c5abm"]
@@ -7,6 +7,28 @@
 [sub_resource type="AtlasTexture" id="AtlasTexture_1gm32"]
 atlas = ExtResource("3_8l7rs")
 region = Rect2(4.58546, 12.3783, 23.1067, 46.777)
+
+[sub_resource type="GDScript" id="GDScript_1cd2p"]
+script/source = "extends Area2D
+
+@onready var sprite = $\"../Sprite\"
+@onready var parent = get_parent()
+signal area_clicked(parent)
+
+func _on_mouse_entered():
+	sprite.modulate = Color(0.9, 0.9, 0.9, 1) 
+
+func _on_mouse_exited():
+	sprite.modulate = Color(1, 1, 1, 1)
+	
+func _input_event(viewport, event, shape_idx):
+	if event.is_action_pressed(\"interact\"):
+		emit_signal(\"area_clicked\", parent)
+	
+"
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_1cd2p"]
+size = Vector2(20, 46)
 
 [node name="Character" type="Node2D"]
 script = ExtResource("1_vxr42")
@@ -18,6 +40,13 @@ script = ExtResource("2_c5abm")
 position = Vector2(0, -8)
 scale = Vector2(0.5, 0.5)
 texture = SubResource("AtlasTexture_1gm32")
+
+[node name="clickableArea" type="Area2D" parent="Sprite"]
+script = SubResource("GDScript_1cd2p")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Sprite/clickableArea"]
+position = Vector2(0, 1)
+shape = SubResource("RectangleShape2D_1cd2p")
 
 [node name="CharacterCamera" type="Camera2D" parent="."]
 scale = Vector2(4, 2)
@@ -37,3 +66,4 @@ scale = Vector2(0.535651, 0.520002)
 [connection signal="turn_complete" from="." to="Path" method="_on_character_unit_still"]
 [connection signal="unit_moving" from="." to="Path" method="_on_character_unit_moving"]
 [connection signal="unit_still" from="." to="Path" method="_on_character_unit_still"]
+[connection signal="area_clicked" from="Sprite/clickableArea" to="." method="_on_area_clicked"]

--- a/Scenes/Character/clickable_area.gd
+++ b/Scenes/Character/clickable_area.gd
@@ -1,0 +1,1 @@
+extends Area2D

--- a/Scenes/Character/clickable_area.gd.uid
+++ b/Scenes/Character/clickable_area.gd.uid
@@ -1,0 +1,1 @@
+uid://ccsmoeym7wdng

--- a/Scenes/Enemy/Enemy.tscn
+++ b/Scenes/Enemy/Enemy.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://cb5p1xnivihi1"]
 
 [ext_resource type="Texture2D" uid="uid://beheelslfnump" path="res://Assets/Sprites/icon.svg" id="1_0cy87"]
-[ext_resource type="Script" uid="uid://cwcjarvd65308" path="res://Scenes/Enemy/enemy.gd" id="2_vxqhh"]
+[ext_resource type="Script" path="res://Scenes/Enemy/enemy.gd" id="2_vxqhh"]
 
 [node name="Enemy" type="Node2D"]
 position = Vector2(2.98023e-08, -2.98023e-08)

--- a/Scenes/UI/User_Interface/turn_scroll.gd
+++ b/Scenes/UI/User_Interface/turn_scroll.gd
@@ -5,7 +5,7 @@ extends Control
 @onready var current_sprite = $HBoxContainer/CurrentSprite
 @onready var previous_sprite = $HBoxContainer/PreviousSprite1
 @onready var future_sprite = $HBoxContainer/FutureSprite1
-@onready var unit_info = $UnitInfo
+@onready var unit_info = $"../UnitInfo"
 
 # fixed sizes for sprites
 @export var current_sprite_size: Vector2 = Vector2(64, 64)

--- a/Scenes/UI/User_Interface/unit_info.gd
+++ b/Scenes/UI/User_Interface/unit_info.gd
@@ -1,4 +1,5 @@
 extends Panel
+
 @onready var unit_name = $UnitName
 @onready var unit_stats = $UnitStats
 @onready var unit_sprite = $UnitSprite

--- a/Scenes/UI/User_Interface/user_interface.gd
+++ b/Scenes/UI/User_Interface/user_interface.gd
@@ -2,6 +2,7 @@ extends CanvasLayer
 class_name UserInterface
 
 @onready var health_bar: MarginContainer = $HealthBar
+@onready var unit_info = $UnitInfo
 
 var active_char
 var active_char_stats
@@ -29,3 +30,9 @@ func _on_ui_element_mouse_exited() -> void:
 func _on_turn_info(order: Variant, current_turn: Variant) -> void:
 	turn_array = order
 	current_turn_index = current_turn
+	
+func _on_unit_clicked(unit):
+	print("UserInterface received unit_clicked signal for:", unit.name)
+	if unit_info:
+		unit_info.update_info(unit)
+		unit_info.visible = true

--- a/Scenes/UI/User_Interface/user_interface.tscn
+++ b/Scenes/UI/User_Interface/user_interface.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="Script" uid="uid://c7xlcgx60sbmg" path="res://Scenes/UI/User_Interface/turn_scroll.gd" id="4_13sfg"]
 [ext_resource type="Texture2D" uid="uid://bqhuok67rdqcj" path="res://Assets/Texture/attack_icon.png" id="5_1aga7"]
 [ext_resource type="Script" uid="uid://cswnqpumxdpea" path="res://Scenes/UI/User_Interface/unit_info.gd" id="5_yx8tb"]
-[ext_resource type="Script" uid="uid://b36td63hn5vf5" path="res://Scenes/UI/User_Interface/attack_button.gd" id="6_kws0h"]
+[ext_resource type="Script" path="res://Scenes/UI/User_Interface/attack_button.gd" id="6_kws0h"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_r2j3s"]
 atlas = ExtResource("3_woo7i")
@@ -22,6 +22,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 script = ExtResource("4_13sfg")
 user_interface_path = NodePath("..")
 
@@ -55,47 +56,6 @@ layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 0
 stretch_mode = 5
-
-[node name="UnitInfo" type="Panel" parent="TurnScroll"]
-layout_mode = 1
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_top = -231.0
-offset_right = 245.0
-grow_vertical = 0
-script = ExtResource("5_yx8tb")
-
-[node name="UnitName" type="Label" parent="TurnScroll/UnitInfo"]
-layout_mode = 1
-anchors_preset = 5
-anchor_left = 0.5
-anchor_right = 0.5
-offset_left = -38.5
-offset_right = 38.5
-offset_bottom = 23.0
-grow_horizontal = 2
-
-[node name="UnitSprite" type="TextureRect" parent="TurnScroll/UnitInfo"]
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -102.5
-offset_top = -75.5
-offset_right = -62.5
-offset_bottom = -35.5
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="UnitStats" type="VBoxContainer" parent="TurnScroll/UnitInfo"]
-layout_mode = 0
-offset_left = 60.0
-offset_top = 40.0
-offset_right = 244.0
-offset_bottom = 229.0
 
 [node name="HealthBar" parent="." instance=ExtResource("2_txa2e")]
 
@@ -187,6 +147,46 @@ layout_mode = 2
 mouse_filter = 1
 icon = SubResource("AtlasTexture_r2j3s")
 expand_icon = true
+
+[node name="UnitInfo" type="Panel" parent="."]
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -231.0
+offset_right = 245.0
+grow_vertical = 0
+script = ExtResource("5_yx8tb")
+
+[node name="UnitName" type="Label" parent="UnitInfo"]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -38.5
+offset_right = 38.5
+offset_bottom = 23.0
+grow_horizontal = 2
+
+[node name="UnitSprite" type="TextureRect" parent="UnitInfo"]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -102.5
+offset_top = -75.5
+offset_right = -62.5
+offset_bottom = -35.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="UnitStats" type="VBoxContainer" parent="UnitInfo"]
+layout_mode = 0
+offset_left = 60.0
+offset_top = 40.0
+offset_right = 244.0
+offset_bottom = 229.0
 
 [connection signal="mouse_entered" from="TurnScroll/HBoxContainer" to="." method="_on_ui_element_mouse_entered"]
 [connection signal="mouse_exited" from="TurnScroll/HBoxContainer" to="." method="_on_ui_element_mouse_exited"]

--- a/Scripts/Utilities/spawnCharacter.gd
+++ b/Scripts/Utilities/spawnCharacter.gd
@@ -32,6 +32,9 @@ func spawn_character(layer: TileMapLayer) -> Character:
 		positions[layer.local_to_map(char_instance.global_position)] = char_instance
 		user_interface.ui_element_mouse_entered.connect(char_instance._ui_element_mouse_entered)
 		user_interface.ui_element_mouse_exited.connect(char_instance._ui_element_mouse_exited)
+		
+		char_instance.unit_clicked.connect(user_interface._on_unit_clicked)
+		
 		return char_instance
 	
 	return spawn_character(layer)


### PR DESCRIPTION
important to note:
-control nodes eat up inputs if they are overlapping and the mouse filter is on stop.